### PR TITLE
fix: enable cors for GET endpoint (#6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2001,6 +2001,21 @@
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-3.0.3.tgz",
       "integrity": "sha512-hykDL6iTjfiJpqFOtLzxn+TO9yI2SP4o9JnRU2ggYWYpH3XvNLXdB+5ClskBG56k2VlIbgCRx1jvycRwtRM2rg=="
     },
+    "@middy/http-cors": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-3.0.4.tgz",
+      "integrity": "sha512-trnUvXqGHdWhiHSlbxTEnZ60I1OJcSIoQ8uLHWlwCDLDmdYMUXNcL0nRj9ZDiltO9qGotu76Lxmobq672pTllw==",
+      "requires": {
+        "@middy/util": "3.0.4"
+      },
+      "dependencies": {
+        "@middy/util": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.0.4.tgz",
+          "integrity": "sha512-NPJ/429n8+coUCpHS8LMIL06FQPBJ8x7oqAtCRDALkR9OvAIJDci4BAYEZDVcnIVq7f3Ee0+a6s1bFmJySCFxA=="
+        }
+      }
+    },
     "@middy/http-error-handler": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@middy/http-error-handler/-/http-error-handler-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@middy/core": "^3.0.3",
+    "@middy/http-cors": "^3.0.4",
     "@middy/http-error-handler": "^3.0.3",
     "@middy/http-json-body-parser": "^3.0.3",
     "aws-sdk": "^2.1141.0",

--- a/src/libs/lambda.ts
+++ b/src/libs/lambda.ts
@@ -1,7 +1,12 @@
 import middy from "@middy/core";
+import middyCors from "@middy/http-cors";
 import middyJsonBodyParser from "@middy/http-json-body-parser";
 import middyErrorHandler from "@middy/http-error-handler";
 
 export const middyfy = (handler) => {
-  return middy(handler).use([middyJsonBodyParser(), middyErrorHandler()]);
+  return middy(handler).use([
+    middyJsonBodyParser(),
+    middyErrorHandler(),
+    middyCors(),
+  ]);
 };


### PR DESCRIPTION
* fix: set Access-Control-Allow-Origin=* on GET endpoint

* fix: change cors back to true

* chore: npm i @middy/http-cors

* fix: add cors middleware

Co-authored-by: David <david_tjokroaminoto@tech.gov.sg>